### PR TITLE
Fix useAxios hook when use multiple times

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,13 +88,14 @@ async function request(config, dispatch) {
   }
 }
 
-export default function useAxios(config) {
-  if (typeof config === 'string') {
-    config = {
-      url: config
-    }
-  }
+function normalizeConfig(config) {
+  return typeof config === 'string' ? {
+    url: config
+  } : { ...config }
+}
 
+export default function useAxios(config) {
+  const config = normalizeConfig(requestConfig)
   const [state, dispatch] = React.useReducer(reducer, initialState)
 
   if (typeof window === 'undefined') {


### PR DESCRIPTION
This PR fixes the `useAxios` hook when it is used multiple times with different config objects. Before use the useEffect hook, he need normalize the config object or create a clone of himself.

