### PR TITLE
Change initial state to loading.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const actions = {
 }
 
 const initialState = {
-  loading: false
+  loading: true
 }
 
 const ssrPromises = []


### PR DESCRIPTION
Always make sure we're initially starting a hook as loading. This is to prevent bugs from occuring where we check for:
```
if loading return ...
if error return ...
```
return data