### PR TITLE
Reset error when request succeeds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,8 @@ function reducer(state, action) {
     case actions.REQUEST_START:
       return {
         ...state,
-        loading: true
+        loading: true,
+        error: null
       }
     case actions.REQUEST_END:
       return {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -9,7 +9,7 @@ test('should set loading to true', async () => {
   expect(result.current[0].loading).toBe(true)
 })
 
-test('should set loading to false when request completes and return data', async () => {
+test('should set loading to false when request completes and returns data', async () => {
   const { result, waitForNextUpdate } = renderHook(() => useAxios())
 
   act(() => {
@@ -22,7 +22,25 @@ test('should set loading to false when request completes and return data', async
   expect(result.current[0].data).toBe('whatever')
 })
 
-test('should set loading to false when request completes and return error', async () => {
+test('should reset error when request completes and returns data', async () => {
+  const { result, waitForNextUpdate } = renderHook(() => useAxios())
+  result.current[0].error = new Error()
+
+  act(() => {
+    axios.resolvePromise({ data: 'whatever' })
+  })
+
+  await waitForNextUpdate()
+
+  // Refetch
+  act(() => {
+    result.current[1]()
+  })
+
+  expect(result.current[0].error).toBe(null)
+})
+
+test('should set loading to false when request completes and returns error', async () => {
   const { result, waitForNextUpdate } = renderHook(() => useAxios())
   const error = new Error('boom')
 


### PR DESCRIPTION
This is a fix for the issue ["error is not reset if subsequent request succeeds"](https://github.com/simoneb/axios-hooks/issues/8).

Pretty sure this is the correct fix but please review!
