### PR TITLE
Add index.d.ts to files array in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "files": [
     "lib",
     "es",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "scripts": {
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src/index.js --out-dir lib",


### PR DESCRIPTION
I think this is the required step to make sure the typescript declaration is included in the built tarball.

If that's not right, then feel free to close.