### PR TITLE
Add missing typing parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,4 +13,4 @@ interface Options {
 export default function useAxios(
   config: AxiosRequestConfig | string,
   options?: Options
-): [ResponseValues, () => void]
+): [ResponseValues, (config?: AxiosRequestConfig) => void]

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,11 @@ interface ResponseValues {
   error?: AxiosError;
 }
 
+interface Options {
+  manual: boolean
+}
+
 export default function useAxios(
-  config: AxiosRequestConfig | string
+  config: AxiosRequestConfig | string,
+  options?: Options
 ): [ResponseValues, () => void]


### PR DESCRIPTION
I noticed that the TypeScript definitions were incorrect for the useAxios function.

I've updated them in this PR so that a user can use manual mode. I commented about this issue [here](https://github.com/simoneb/axios-hooks/issues/5)