### PR TITLE
Change ResponseValues to a generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig, AxiosError, AxiosPromise } from 'axios'
 
-interface ResponseValues {
-  data: any
+interface ResponseValues<T> {
+  data: T
   loading: boolean
   error?: AxiosError
 }
@@ -14,10 +14,10 @@ interface RefetchOptions {
   useCache: boolean
 }
 
-export default function useAxios(
+export default function useAxios<T = any>(
   config: AxiosRequestConfig | string,
   options?: Options
 ): [
-  ResponseValues,
+  ResponseValues<T>,
   (config?: AxiosRequestConfig, options?: RefetchOptions) => void
 ]


### PR DESCRIPTION
Hi,

I really find this package usefull but just needs it to be a bit more strongly typed :-) ! 

This PR should allow typescript users to provide the Response type when using useAxios in the following manner:
`const [{data, loading, error}, execute] = useAxios<ResponseType>(...)` 

This should also be fully backward compatible since it still defaults to any :-)  !