### PR TITLE
Fixed useAxios url

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ function App() {
 
 ### API
 
-- [useAxios](#useaxiosurlconfig)
+- [useAxios](#useaxiosurlconfig-options)
 - [configure](#configure-cache-axios-)
 - [serializeCache](#serializeCache)
 - [loadCache](#loadcachecache)


### PR DESCRIPTION
The reference in the markdown to the **useAxios** section is **useaxiosurlconfig**, but it should be **useaxiosurlconfig-options**