### PR TITLE
Add useCache option for standard useAxios call

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ interface ResponseValues<T> {
 
 interface Options {
   manual?: boolean;
+  useCache?: boolean;
 }
 
 interface RefetchOptions {

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,10 @@ function executeRequestWithoutCache(config, dispatch) {
   return request(config, dispatch)
 }
 
-export default function useAxios(config, options = { manual: false }) {
+export default function useAxios(
+  config,
+  options = { manual: false, useCache: true }
+) {
   if (typeof config === 'string') {
     config = {
       url: config
@@ -124,7 +127,9 @@ export default function useAxios(config, options = { manual: false }) {
 
   React.useEffect(() => {
     if (!options.manual) {
-      executeRequestWithCache(config, dispatch)
+      options.useCache
+        ? executeRequestWithCache(config, dispatch)
+        : executeRequestWithoutCache(config, dispatch)
     }
   }, [JSON.stringify(config)])
 


### PR DESCRIPTION
Fixes #33 

I tried but I couldn't manage to write a working test for it.

Something like spying on `lru-cache` `get` would be nice, but I'm not sure how to spy on it, since it's instantiated in `index.js` with `new LRU()`.
