### PR TITLE
fix: correctly handles errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,8 +80,8 @@ function reducer(state, action) {
       return {
         ...state,
         loading: false,
-        ...(action.error ? {} : { data: action.payload.data }),
-        [action.error ? 'error' : 'response']: action.payload
+        data: action.payload && action.payload.data,
+        [action.error ? 'error' : 'response']: action.payload || !action.payload
       }
     default:
       return state
@@ -92,9 +92,17 @@ async function request(config, dispatch) {
   try {
     dispatch({ type: actions.REQUEST_START })
     const response = await axiosInstance(config)
-    dispatch({ type: actions.REQUEST_END, payload: response })
+    dispatch({
+      type: actions.REQUEST_END,
+      payload: response,
+      error: !response || !response.data
+    })
   } catch (err) {
-    dispatch({ type: actions.REQUEST_END, payload: err, error: true })
+    dispatch({
+      type: actions.REQUEST_END,
+      payload: err,
+      error: true
+    })
   }
 }
 


### PR DESCRIPTION
It seems that `axios-hooks` doesn't always correctly handles response code of `500` or `404`, as shown below. 
![Screenshot from 2019-10-11 18-00-48](https://user-images.githubusercontent.com/29411227/66702048-77141380-ed03-11e9-8fae-b41fe19629c2.png)
This __P.R__ addresses this problem.
I've tested it both with the provided test suite (no needs to add other tests) and in the upper mentioned project where the image came from.
I can confirm that everything is working fine now.