### PR TITLE
Return AxiosPromise of generic type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ export default function useAxios<T = any>(
   options?: Options
 ): [
   ResponseValues<T>,
-  (config?: AxiosRequestConfig, options?: RefetchOptions) => AxiosPromise
+  (config?: AxiosRequestConfig, options?: RefetchOptions) => AxiosPromise<T>
 ]
 
 export function loadCache(data: any[]): void


### PR DESCRIPTION
When invoking `refetch` method manually, it still returns the `AxiosPromise`, however it has no type defined.
Since we may set this generic type manually, it should use it as well with returned promise.