### PR TITLE
Prevent state changes in useAxios for unmounted components

### DIFF
--- a/axios.d.ts
+++ b/axios.d.ts
@@ -2,6 +2,8 @@ import { AxiosStatic } from "axios";
 
 declare module "axios" {
   interface AxiosStatic {
+    mockReset: Function;
+    mockImplementationOnce: Function;
     mockImplementation: Function;
     mockResolvedValue: Function;
     mockResolvedValueOnce: Function;

--- a/axios.d.ts
+++ b/axios.d.ts
@@ -2,6 +2,7 @@ import { AxiosStatic } from "axios";
 
 declare module "axios" {
   interface AxiosStatic {
+    mockImplementation: Function;
     mockResolvedValue: Function;
     mockResolvedValueOnce: Function;
     mockRejectedValue: Function;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -6,6 +6,8 @@ import useAxios, { configure, resetConfigure } from './'
 jest.mock('axios')
 
 it('should set loading to true', async () => {
+  axios.mockImplementation(() => new Promise(() => null))
+
   const { result } = renderHook(() => useAxios(''))
 
   expect(result.current[0].loading).toBe(true)
@@ -84,11 +86,13 @@ it('should refetch', async () => {
 
   expect(result.current[0].loading).toBe(true)
   expect(axios).toHaveBeenCalledTimes(2)
+
+  await waitForNextUpdate()
 })
 
 describe('refetch', () => {
   describe('when axios resolves', () => {
-    it('should resolve to the response by default', () => {
+    it('should resolve to the response by default', async () => {
       const response = { data: 'whatever' }
 
       axios.mockResolvedValue(response)
@@ -99,12 +103,12 @@ describe('refetch', () => {
         }
       } = renderHook(() => useAxios(''))
 
-      act(() => {
+      await act(async () => {
         expect(refetch()).resolves.toEqual(response)
       })
     })
 
-    it('should resolve to the response when using cache', () => {
+    it('should resolve to the response when using cache', async () => {
       const response = { data: 'whatever' }
 
       axios.mockResolvedValue(response)
@@ -115,14 +119,14 @@ describe('refetch', () => {
         }
       } = renderHook(() => useAxios(''))
 
-      act(() => {
+      await act(async () => {
         expect(refetch({}, { useCache: true })).resolves.toEqual(response)
       })
     })
   })
 
   describe('when axios rejects', () => {
-    it('should reject with the error by default', () => {
+    it('should reject with the error by default', async () => {
       const error = new Error('boom')
 
       axios.mockRejectedValue(error)
@@ -133,12 +137,12 @@ describe('refetch', () => {
         }
       } = renderHook(() => useAxios(''))
 
-      act(() => {
+      await act(async () => {
         expect(refetch()).rejects.toEqual(error)
       })
     })
 
-    it('should reject with the error by when using cache', () => {
+    it('should reject with the error by when using cache', async () => {
       const error = new Error('boom')
 
       axios.mockRejectedValue(error)
@@ -149,7 +153,7 @@ describe('refetch', () => {
         }
       } = renderHook(() => useAxios(''))
 
-      act(() => {
+      await act(async () => {
         expect(refetch({}, { useCache: true })).rejects.toEqual(error)
       })
     })
@@ -159,17 +163,18 @@ describe('refetch', () => {
 it('should return the same reference to the fetch function', async () => {
   axios.mockResolvedValue({ data: 'whatever' })
 
-  const { result, rerender } = renderHook(() => useAxios(''))
+  const { result, rerender, waitForNextUpdate } = renderHook(() => useAxios(''))
 
   const firstRefetch = result.current[1]
 
   rerender()
+  await waitForNextUpdate()
 
   expect(result.current[1]).toBe(firstRefetch)
 })
 
 describe('manual option', () => {
-  it('should set loading to false', async () => {
+  it('should set loading to false', () => {
     const { result } = renderHook(() => useAxios('', { manual: true }))
 
     expect(result.current[0].loading).toBe(false)
@@ -258,8 +263,8 @@ describe('useCache option', () => {
 describe('configure', () => {
   afterEach(() => resetConfigure())
 
-  it('should provide a custom implementation of axios', () => {
-    const mockAxios = jest.fn()
+  it('should provide a custom implementation of axios', async () => {
+    const mockAxios = jest.fn(() => new Promise(() => null))
 
     configure({ axios: mockAxios })
 


### PR DESCRIPTION
This pull request fixes the following React error if an Axios request completes on an unmounted component. It does this by using a React ref object to keep track of whether the object has been dismounted or not. If the component has been dismounted it will not try to update its state which would trigger this error to occur.

```
Warning: Can't perform a React state update on an unmounted component. This is a
no-op, but it indicates a memory leak in your application
```

Several of the tests have also been updated to avoid the following error being reported in the tests:

```
      Warning: An update to TestHook inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
```