### PR TITLE
Fixing Unhandled Promise Rejection when fetching manually

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,7 +196,7 @@ export function makeUseAxios(configurationOptions) {
           },
           { useCache: false, ...options },
           dispatch
-        )
+        ).catch(() => {})
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [stringifiedConfig]


### PR DESCRIPTION
We need to handle the promise rejection on the `refetch` method.