### PR TITLE
perf: optimize re-rendering with correct initState

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,8 @@ export function makeUseAxios(configurationOptions) {
 
   function createInitialState(options) {
     return {
-      loading: !options.manual
+      loading: !options.manual,
+      error: null
     }
   }
 


### PR DESCRIPTION
The original rendering behaviour of `useAxios` is normally rendering 3 times because the `error` property is undefined on the first run and turns `null` on the second run, then when getting results comes the third time.

There's actually an extra update due to the undefined `error`.

Quick check: https://codesandbox.io/s/axios-hooks-quick-start-278dc?fontsize=14&hidenavigation=1&theme=dark

This PR adds the initial `error: null` to improve the performance.