### PR TITLE
Return cancel outstanding request

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,7 +40,8 @@ export interface UseAxios {
     (
       config?: AxiosRequestConfig,
       options?: RefetchOptions
-    ) => AxiosPromise<TResponse>
+    ) => AxiosPromise<TResponse>,
+    () => void
   ]
 
   loadCache(data: any[]): void

--- a/src/index.js
+++ b/src/index.js
@@ -264,6 +264,6 @@ export function makeUseAxios(configureOptions) {
       [config, withCancelToken]
     )
 
-    return [state, refetch]
+    return [state, refetch, cancelOutstandingRequest]
   }
 }

--- a/test/index.test.jsx
+++ b/test/index.test.jsx
@@ -437,6 +437,20 @@ function standardTests(
         expect(cancel).not.toHaveBeenCalled()
       })
 
+      it('should cancel the outstanding request when the cancel method is called after the component rerenders with same config', async () => {
+        axios.mockResolvedValue({ data: 'whatever' })
+
+        const { waitForNextUpdate, rerender, result } = setup('initial config')
+
+        await waitForNextUpdate()
+
+        rerender()
+
+        result.current[2]()
+
+        expect(cancel).toHaveBeenCalled()
+      })
+
       it('should not dispatch an error when the request is canceled', async () => {
         const cancellation = new Error('canceled')
 
@@ -515,6 +529,22 @@ function standardTests(
         expect(cancel).toHaveBeenCalled()
 
         await waitForNextUpdate()
+      })
+
+      it('should cancel the outstanding manual refetch when the cancel method is called', async () => {
+        axios.mockResolvedValue({ data: 'whatever' })
+
+        const { result, waitForNextUpdate } = setup('', { manual: true })
+
+        act(() => {
+          result.current[1]()
+        })
+
+        await waitForNextUpdate()
+
+        result.current[2]()
+
+        expect(cancel).toHaveBeenCalled()
       })
 
       it('should throw an error when the request is canceled', async () => {

--- a/test/index.test.jsx
+++ b/test/index.test.jsx
@@ -399,6 +399,18 @@ function standardTests(
         expect(cancel).toHaveBeenCalled()
       })
 
+      it('should cancel the outstanding request when the cancel method is called', async () => {
+        axios.mockResolvedValue({ data: 'whatever' })
+
+        const { waitForNextUpdate, result } = setup()
+
+        await waitForNextUpdate()
+
+        result.current[2]()
+
+        expect(cancel).toHaveBeenCalled()
+      })
+
       it('should cancel the outstanding request when the component refetches due to a rerender', async () => {
         axios.mockResolvedValue({ data: 'whatever' })
 


### PR DESCRIPTION
Per #376. 

Adds the `cancelOutstandingRequest` to the hook return to allow for manual cancellation of a request.