### PR TITLE
feature(manual cancellation update): Reset loading state when outstanding call is cancelled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -250,7 +250,7 @@ export function makeUseAxios(configureOptions) {
         request(withCancelToken(config), options, dispatch).catch(() => {})
       }
 
-      return () => cancelOutstandingRequest()
+      return cancelOutstandingRequest
     }, [config, options, withCancelToken, cancelOutstandingRequest])
 
     const refetch = React.useCallback(

--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,7 @@ export function makeUseAxios(configureOptions) {
         ).catch(() => {})
       }
 
-      return () => { cancelOutstandingRequest(options.manual)}
+      return cancelOutstandingRequest
     }, [config, options, withCancelToken, cancelOutstandingRequest])
 
     const refetch = React.useCallback(

--- a/src/index.js
+++ b/src/index.js
@@ -226,16 +226,11 @@ export function makeUseAxios(configureOptions) {
       useAxios.__ssrPromises.push(axiosInstance(config))
     }
 
-    const cancelOutstandingRequest = React.useCallback(manualCancel => {
+    const cancelOutstandingRequest = React.useCallback(() => {
       if (cancelSourceRef.current) {
         cancelSourceRef.current.cancel()
       }
     }, [])
-
-    const cancelManually = React.useCallback(
-      () => cancelOutstandingRequest(true),
-      [cancelOutstandingRequest]
-    )
 
     const withCancelToken = React.useCallback(
       config => {
@@ -255,7 +250,7 @@ export function makeUseAxios(configureOptions) {
         request(withCancelToken(config), options, dispatch).catch(() => {})
       }
 
-      return () => cancelOutstandingRequest(options.manual)
+      return () => cancelOutstandingRequest()
     }, [config, options, withCancelToken, cancelOutstandingRequest])
 
     const refetch = React.useCallback(
@@ -274,7 +269,7 @@ export function makeUseAxios(configureOptions) {
       [config, withCancelToken]
     )
 
-    return [state, refetch, cancelManually]
+    return [state, refetch, cancelOutstandingRequest]
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,7 @@ export function makeUseAxios(configureOptions) {
         ).catch(() => {})
       }
 
-      return cancelOutstandingRequest
+      return () => { cancelOutstandingRequest(options.manual)}
     }, [config, options, withCancelToken, cancelOutstandingRequest])
 
     const refetch = React.useCallback(

--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,12 @@ export function makeUseAxios(configureOptions) {
     return response
   }
 
-  async function executeRequest(config, dispatch, isMounted, isCancelledManually) {
+  async function executeRequest(
+    config,
+    dispatch,
+    isMounted,
+    isCancelledManually
+  ) {
     try {
       dispatch({ type: actions.REQUEST_START })
 
@@ -197,7 +202,13 @@ export function makeUseAxios(configureOptions) {
     }
   }
 
-  async function request(config, options, dispatch, isMounted, isCancelledManually) {
+  async function request(
+    config,
+    options,
+    dispatch,
+    isMounted,
+    isCancelledManually
+  ) {
     return (
       tryGetFromCache(config, options, dispatch) ||
       executeRequest(config, dispatch, isMounted, isCancelledManually)
@@ -218,7 +229,7 @@ export function makeUseAxios(configureOptions) {
     )
 
     const isCancelledManually = React.useRef(false)
-    const isMounted = React.useRef(false);
+    const isMounted = React.useRef(false)
     const cancelSourceRef = React.useRef()
 
     const [state, dispatch] = React.useReducer(
@@ -257,10 +268,12 @@ export function makeUseAxios(configureOptions) {
       [cancelOutstandingRequest]
     )
     React.useEffect(() => {
-      isMounted.current = true;
-      return () => { isMounted.current = false; }
+      isMounted.current = true
+      return () => {
+        isMounted.current = false
+      }
     }, [])
-    
+
     React.useEffect(() => {
       if (!options.manual) {
         request(

--- a/src/index.js
+++ b/src/index.js
@@ -193,9 +193,11 @@ export function makeUseAxios(configureOptions) {
     } catch (err) {
       if (!StaticAxios.isCancel(err)) {
         dispatch({ type: actions.REQUEST_END, payload: err, error: true })
-      } else if (isMounted.current && isCancelledManually.current) {
-        isCancelledManually.current = false
-        dispatch({ type: actions.REQUEST_END, isManualCancel: true })
+      } else {
+        if (isMounted.current && isCancelledManually.current) {
+          isCancelledManually.current = false
+          dispatch({ type: actions.REQUEST_END, isManualCancel: true })
+        }
       }
 
       throw err
@@ -252,7 +254,7 @@ export function makeUseAxios(configureOptions) {
 
     const cancelManually = React.useCallback(
       () => cancelOutstandingRequest(true),
-      []
+      [cancelOutstandingRequest]
     )
 
     const withCancelToken = React.useCallback(

--- a/test/index.test.jsx
+++ b/test/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import axios from 'axios'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, wait, waitFor } from '@testing-library/react'
 import { renderHook, act } from '@testing-library/react-hooks'
 
 import defaultUseAxios, {
@@ -408,7 +408,8 @@ function standardTests(
 
         result.current[2]()
 
-        expect(cancel).toHaveBeenCalled()
+        expect(cancel).toHaveBeenCalledTimes(1)
+        expect(result.current[0].loading).toBe(false)
       })
 
       it('should cancel the outstanding request when the component refetches due to a rerender', async () => {
@@ -449,6 +450,7 @@ function standardTests(
         result.current[2]()
 
         expect(cancel).toHaveBeenCalled()
+        expect(result.current[0].loading).toBe(false)
       })
 
       it('should not dispatch an error when the request is canceled', async () => {
@@ -544,7 +546,28 @@ function standardTests(
 
         result.current[2]()
 
-        expect(cancel).toHaveBeenCalled()
+        expect(cancel).toHaveBeenCalledTimes(1)
+        expect(result.current[0].loading).toBe(false)
+      })
+
+      it('should cancel manual request when the config options change', async () => {
+        axios.mockResolvedValue({ data: 'whatever' })
+
+        const { result, waitForNextUpdate, rerender } = setup('', {
+          manual: true
+        })
+
+        act(() => {
+          result.current[1]()
+        })
+
+        rerender({ config: 'new url', options: { manual: true } })
+
+        await waitForNextUpdate()
+
+        expect(result.current[0].loading).toBe(false)
+        expect(cancel).toHaveBeenCalledTimes(1)
+        expect(axios).toHaveBeenCalledTimes(1)
       })
 
       it('should throw an error when the request is canceled', async () => {

--- a/test/index.test.jsx
+++ b/test/index.test.jsx
@@ -489,6 +489,20 @@ function standardTests(
         expect(result.current[0].loading).toBe(false)
       })
 
+      it('should not dispatch an error when the request is canceled', async () => {
+        const cancellation = new Error('canceled')
+
+        axios.mockRejectedValueOnce(cancellation)
+        axios.isCancel = jest
+          .fn()
+          .mockImplementationOnce(err => err === cancellation)
+
+        const { result, waitForNextUpdate } = setup('')
+
+        await waitForNextUpdate()
+        expect(result.current[0].error).toBeNull()
+      })
+
       it('should return previous state after cancel', async () => {
         const response = { data: 'whatever' }
 

--- a/test/index.test.jsx
+++ b/test/index.test.jsx
@@ -489,28 +489,6 @@ function standardTests(
         expect(result.current[0].loading).toBe(false)
       })
 
-      it('should not dispatch an error when the request is canceled', async () => {
-        const cancellation = new Error('canceled')
-
-        axios.mockRejectedValueOnce(cancellation)
-        axios.isCancel = jest
-          .fn()
-          .mockImplementationOnce(err => err === cancellation)
-
-        const { result, waitFor } = setup('')
-
-        // if we cancel we won't dispatch the error, hence there's no state update
-        // to wait for. yet, if we don't try to wait, we won't know if we're handling
-        // the error properly because the return value will not have the error until a
-        // state update happens. it would be great to have a better way to test this
-        await waitFor(
-          () => {
-            expect(result.current[0].error).toBeNull()
-          },
-          { timeout: 1000, suppressErrors: false }
-        )
-      })
-
       it('should return previous state after cancel', async () => {
         const response = { data: 'whatever' }
 

--- a/test/index.test.jsx
+++ b/test/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import axios from 'axios'
-import { render, fireEvent, wait, waitFor } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import { renderHook, act } from '@testing-library/react-hooks'
 
 import defaultUseAxios, {


### PR DESCRIPTION
Here's a proposal for #372 

1. Resets the loading property (and keeps previous state) when a outstanding call is cancelled via the manualCancel method. 
   - This required tracking how the `cancelOutstandingRequest` is called with the `isCancelledManually` ref. The state update only occurs when the `cancelManually` method is executed.

2. Resets the loading property when a manual call is cancelled via a config change to the hook (on new line 375). 
   - Required checking that the component is mounted as it attempts to update the state on a config change (that is also triggered on an unmount). This was done with the `isMounted` ref and the empty dependency useEffect.
 
    *Note:* Point 2 is done under the assumption that changes in the config and option should cancel a outstanding request when the manual property is true per #372.

The sandbox shows the operation of the PR. Clicking the `cancel request` button will reset the `loading` property and keep the previous state. Likewise, updating the hook config will cancel and reset the `loading` property.

https://codesandbox.io/s/axios-hooks-manual-cancel-updates-wvv4z?file=/src/App.js

Closes #372 