### PR TITLE
feat(typings): expose return type of useAxios

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,18 +31,20 @@ export interface ConfigureOptions {
   defaultOptions?: Options
 }
 
+export type UseAxiosResult<TResponse = any, TError = any> = [
+  ResponseValues<TResponse, TError>,
+  (
+    config?: AxiosRequestConfig,
+    options?: RefetchOptions
+  ) => AxiosPromise<TResponse>,
+  () => void
+]
+
 export interface UseAxios {
   <TResponse = any, TError = any>(
     config: AxiosRequestConfig | string,
     options?: Options
-  ): [
-    ResponseValues<TResponse, TError>,
-    (
-      config?: AxiosRequestConfig,
-      options?: RefetchOptions
-    ) => AxiosPromise<TResponse>,
-    () => void
-  ]
+  ): UseAxiosResult<TResponse, TError>
 
   loadCache(data: any[]): void
   serializeCache(): Promise<any[]>


### PR DESCRIPTION
When wrapping `useAxios`, it is a little hard to write return type of wrapper hook.

```typescript
import type { AxiosRequestConfig, AxiosPromise } from 'axios';
import useAxios, { ResponseValues, RefetchOptions } from 'axios-hooks';

type MyAPIResponse = { ok: boolean };

function useMyAPI(): [
  ResponseValues<MyAPIResponse, any>,
  (
    config?: AxiosRequestConfig,
    options?: RefetchOptions
  ) => AxiosPromise<MyAPIResponse>,
  () => void
] {
  return useAxios<MyAPIResponse>({ url: 'https://api.example.com/' });
}
```

I think It is convenient if we can write as following:

```typescript
import useAxios, { UseAxiosResult } from 'axios-hooks';

type MyAPIResponse = { ok: boolean };

function useMyAPI(): UseAxiosResult<MyAPIResponse> {
  return useAxios<MyAPIResponse>({ url: 'https://api.example.com/' });
}
```
