### PR TITLE
Typescript: Fix `ResponseValues['error']` to match the null value returned.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,7 +11,7 @@ import LRUCache from 'lru-cache'
 export interface ResponseValues<TResponse, TError> {
   data?: TResponse
   loading: boolean
-  error?: AxiosError<TError>
+  error: AxiosError<TError> | null
   response?: AxiosResponse<TResponse>
 }
 


### PR DESCRIPTION
I have no issue to reference, figured a PR would suffice; happy to make one if desired.

Happy there's definitions included, but I noticed in implementing this, the type returned by error in `const [{ error }] = useAxios('…')` was coming back as an `AxiosError | undefined`, but in the code ([at L137](https://github.com/simoneb/axios-hooks/blob/master/src/index.js#L137) + [at L148](https://github.com/simoneb/axios-hooks/blob/master/src/index.js#L148)) it is set to `null` and never `undefined`.

**My investigation:**
1. It looks like this is always provided, never `undefined`.
2. It looks like this is either defined as `null` ([L137](https://github.com/simoneb/axios-hooks/blob/master/src/index.js#L137), [L148](https://github.com/simoneb/axios-hooks/blob/master/src/index.js#L148)) or via a payload an error object ([L155](https://github.com/simoneb/axios-hooks/blob/master/src/index.js#L155)).