### PR TITLE
Support react 18 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "axios": ">=0.24.0",
-    "react": "^16.8.0-0 || ^17.0.0"
+    "react": "^16.8.0-0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.17.6",


### PR DESCRIPTION
I noticed that the package requires React ^16.8.0-0 or ^17.0.0 as a peer dependency, but ^18.0.0 is not accepted. This causes problems with npm 7+ as peer dependency conflicts completely block dependency installations.