### PR TITLE
docs: correct a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The main React hook to execute HTTP requests.
 
   **Returns**
 
-  A promise containing the response. If the request is unsuccessful, the promise reects and the rejection must be handled manually.
+  A promise containing the response. If the request is unsuccessful, the promise rejects and the rejection must be handled manually.
 
 - `manualCancel()` - A function to cancel outstanding requests manually.
 


### PR DESCRIPTION
## Summary
Fixes a typo in the README.md file

## Changes made
- Corrected the typo from `reects` to `rejects`

## Context
The original sentence read:

> Returns
> 
> A promise containing the response. If the request is unsuccessful, the promise **reects** and the rejection must be handled manually.

The corrected sentence now reads:

> **Returns**
>
>  A promise containing the response. If the request is unsuccessful, the promise **rejects** and the rejection must be handled manually.

## Why this is Necessary:
This change improves the clarity and correctness of the documentation by fixing a typographical error.

## Appreciation Message:
I would also like to take this opportunity to express my gratitude for the well-elaborated documentation and the exceptional support provided by the library. The clarity of explanations and the collaborative community have greatly contributed to my current project.

## Checklist:
- [x]  I only corrected the typo mentioned above
- [x] I have followed the GitHub Community Guidelines

